### PR TITLE
making collapse_viral_abundances_by_host. fail gracefully if no viruses

### DIFF
--- a/post_pipeline_scripts/collapse_viral_abundances_by_host.py
+++ b/post_pipeline_scripts/collapse_viral_abundances_by_host.py
@@ -14,6 +14,12 @@ def main():
     host_prediction = pd.read_csv(host_file, sep="\t")
     #filteing-in only viral species
     profile_viral_species = profile[(profile.Taxon_Lineage_with_Names.str.contains("superkingdom_Viruses")) & (profile.Taxon_Lineage_with_Names.str.contains("species"))]
+    if profile_viral_species.empty:
+        header = "Taxon," + ",".join(profile.columns[2:])
+        with open(out, "w") as outf:
+            sys.stderr.write("No viral species present; exiting\n")
+            outf.write(header + "\n")
+        sys.exit()
     #merging dataframes by species taxonomy id
     species_taxa = profile_viral_species.Taxon_Lineage_with_IDs.str.split("_").str[-1]
     profile_viral_species.insert(loc=2, column='species_taxonomy', value=species_taxa.astype(int))


### PR DESCRIPTION
In cases where a sample contains no virus, this warns the user and writes out an file with the expected headers but no counts. Otherwise, the script tries to operate on an empty df and throws the following error:
```
  File "/home/mambauser/phanta/post_pipeline_scripts/collapse_viral_abundances_by_host.py", line 46, in <module>
    main()
  File "/home/mambauser/phanta/post_pipeline_scripts/collapse_viral_abundances_by_host.py", line 39, in main
    if taxon.iloc[1].dtype=='float': #normalize to 1 if relative abundance was given
  File "/opt/conda/lib/python3.10/site-packages/pandas/core/indexing.py", line 967, in __getitem__
    return self._getitem_axis(maybe_callable, axis=axis)
  File "/opt/conda/lib/python3.10/site-packages/pandas/core/indexing.py", line 1520, in _getitem_axis
    self._validate_integer(key, axis)
  File "/opt/conda/lib/python3.10/site-packages/pandas/core/indexing.py", line 1452, in _validate_integer
    raise IndexError("single positional indexer is out-of-bounds")
IndexError: single positional indexer is out-of-bounds
```

Feel free to reject if you prefer the current behavior!