### PR TITLE
More efficient table merging

### DIFF
--- a/pipeline_scripts/merge.py
+++ b/pipeline_scripts/merge.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+
+import argparse
+import os
+import sys
+import concurrent.futures
+
+import pandas as pd
+
+
+def read_table(table):
+    sample_id = os.path.basename(table).split(".krak.report")[0]
+
+    if os.path.exists(table):
+        try:
+            df = pd.read_csv(table, sep="\t", names=["Taxon_Lineage_with_Names", "Taxon_Lineage_with_IDs", sample_id])\
+            .set_index(["Taxon_Lineage_with_Names", "Taxon_Lineage_with_IDs"])
+        except pd.errors.EmptyDataError:
+            print(f"{table} is empty, pleae check")
+            return None
+
+        if not df.empty:
+            return df
+        else:
+            return None
+    else:
+        print(f"{table} doesn't exists")
+        return None
+
+
+def merge_tables(table_files, workers, **kwargs):
+    dfs = []
+    with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
+        for df in executor.map(read_table, table_files):
+            if df is not None:
+                dfs.append(df)
+
+    df_all = pd.concat(dfs, axis=1).fillna(0).reset_index()
+
+    if "output" in kwargs:
+        df_all.to_csv(kwargs["output"], sep="\t", index=False)
+
+
+def main():
+    parser = argparse.ArgumentParser("profile merger")
+    parser.add_argument("--input-file", dest="input_file", nargs="+")
+    parser.add_argument("--output-file", dest="output_file")
+    parser.add_argument("--threads", dest="threads")
+
+    args = parser.parse_args()
+
+    merge_tables(args.input_file, int(args.threads), output=args.output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/pipeline_scripts/merging_scaled_bracken.py
+++ b/pipeline_scripts/merging_scaled_bracken.py
@@ -1,66 +1,111 @@
+import argparse
 import sys
+import os
+import pandas as pd
+import concurrent.futures
 
-db, temp_file, outdir = sys.argv[1], sys.argv[2], sys.argv[3]
 
-# make a few helpful dictionaries
+def read_scaled_table(table):
+    sample_id = os.path.basename(table).split(".krak.report")[0]
 
-with open(db + '/taxonomy/nodes.dmp', 'r') as infile:
+    if os.path.exists(table):
+        try:
+            df = pd.read_csv(table, sep="\t", dtype={'taxonomy_id': 'string'})\
+            .loc[:, ["taxonomy_id", "rel_taxon_abundance"]]\
+            .rename(columns={"taxonomy_id": "TaxID", "rel_taxon_abundance": sample_id})\
+            .set_index("TaxID")
+        except pd.errors.EmptyDataError:
+            print(f"{table} is empty, pleae check")
+            return None
 
-  # make a child to parent dictionary
-  # and a taxid to rank dictionary
-  child_to_parent = {}
-  taxid_to_rank = {}
-  for line in infile:
-    line=line.rstrip('\n').split('\t')
-    child, parent, rank = line[0], line[2], line[4]
-    child_to_parent[child] = parent
-    taxid_to_rank[child] = rank
+        if not df.empty:
+            return df
+        else:
+            return None
+    else:
+        print(f"{table} doesn't exists")
+        return None
 
-# also want a taxid_to_name dictionary
-# use the inspect.out file
 
-with open(db + '/inspect.out', 'r') as infile:
-  taxid_to_name = {}
-  for line in infile:
-    line=line.rstrip('\n').split('\t')
-    taxid, name = line[4], line[5].strip()
-    taxid_to_name[taxid] = name
+def merge_tables(table_files, workers, **kwargs):
+    dfs = []
+    with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:
+        for df in executor.map(read_scaled_table, table_files):
+            if df is not None:
+                dfs.append(df)
 
-def taxid_to_lineages(taxid):
-  # look up the specific taxid,
-  # build the lineages using the dictionaries
+    df_all = pd.concat(dfs, axis=1).fillna(0).reset_index()
 
-  # first deal with the special case of unclassiifed
-  if taxid == '0':
-    return 'unclassified'
+    if "output" in kwargs:
+        df_all.to_csv(kwargs["output"], sep="\t", index=False)
+    return df_all
 
-  # not unclassified - proceed
-  rank = taxid_to_rank[taxid]
-  lineage_taxids = rank + '_' + taxid
-  lineage_names = rank + '_' + taxid_to_name[taxid]
-  child, parent = taxid, None
 
-  while not parent == '1':
-    # look up child, add to lineages
-    parent = child_to_parent[child]
-    parent_rank = taxid_to_rank[parent]
-    # look up the name of the parent too
-    parent_name = taxid_to_name[parent]
-    lineage_taxids = parent_rank + '_' + parent + '|' + lineage_taxids
-    lineage_names = parent_rank + '_' + parent_name + '|' + lineage_names
-    child = parent # needed for recursion
-  return lineage_names, lineage_taxids
+def taxid_to_lineages(taxid_to_rank, taxid_to_name, child_to_parent, taxid):
+    # look up the specific taxid,
+    # build the lineages using the dictionaries
 
-with open(temp_file, 'r') as infile:
-  with open(outdir + '/relative_taxonomic_abundance.txt', 'w') as outfile:
-    # first fix the header
-    orig_header = infile.readline().rstrip('\n').split('\t')
-    new_header = '\t'.join(['Taxon_Lineage_with_Names', 'Taxon_Lineage_with_IDs'] + orig_header[1:]) + '\n'
-    outfile.write(new_header)
-    for line in infile:
-      line=line.rstrip('\n').split('\t')
-      # use the function to figure out what we want to call this line
-      taxid = line[0]
-      lin_names, lin_ids = taxid_to_lineages(taxid)
-      outlist = [lin_names, lin_ids] + line[1:]
-      outfile.write('\t'.join(outlist) + '\n')
+    # first deal with the special case of unclassiifed
+    if taxid == '0':
+        return 'unclassified'
+
+    # not unclassified - proceed
+    rank = taxid_to_rank[taxid]
+    lineage_taxids = rank + '_' + taxid
+    lineage_names = rank + '_' + taxid_to_name[taxid]
+    child, parent = taxid, None
+
+    while not parent == '1':
+        # look up child, add to lineages
+        parent = child_to_parent[child]
+        parent_rank = taxid_to_rank[parent]
+        # look up the name of the parent too
+        parent_name = taxid_to_name[parent]
+        lineage_taxids = parent_rank + '_' + parent + '|' + lineage_taxids
+        lineage_names = parent_rank + '_' + parent_name + '|' + lineage_names
+        child = parent # needed for recursion
+    return lineage_names, lineage_taxids
+
+
+def main():
+    parser = argparse.ArgumentParser("profile merger")
+    parser.add_argument("--input-file", dest="input_file", nargs="+")
+    parser.add_argument("--output-file", dest="output_file")
+    parser.add_argument("--db", dest="db")
+    parser.add_argument("--threads", dest="threads")
+
+    args = parser.parse_args()
+
+    # make a few helpful dictionaries
+    child_to_parent = {}
+    taxid_to_rank = {}
+    with open(os.path.join(args.db, 'taxonomy/nodes.dmp'), 'r') as infile:
+        # make a child to parent dictionary
+        # and a taxid to rank dictionary
+        for line in infile:
+            line=line.rstrip('\n').split('\t')
+            child, parent, rank = line[0], line[2], line[4]
+            child_to_parent[str(child)] = parent
+            taxid_to_rank[str(child)] = rank
+
+    # also want a taxid_to_name dictionary
+    # use the inspect.out file
+    taxid_to_name = {}
+    with open(os.path.join(args.db, 'inspect.out'), 'r') as infile:
+        for line in infile:
+            line=line.rstrip('\n').split('\t')
+            taxid, name = line[4], line[5].strip()
+            taxid_to_name[str(taxid)] = name
+
+    # merge scaled bracken tables
+    prof_df = merge_tables(args.input_file, int(args.threads))
+
+    samples_list = list(prof_df.columns)[1:]
+    headers = ["Taxon_Lineage_with_Names", "Taxon_Lineage_with_IDs"]
+    prof_df[headers] = prof_df.apply(lambda x: taxid_to_lineages(taxid_to_rank, taxid_to_name, child_to_parent, x["TaxID"]), axis=1, result_type="expand")
+    prof_df = prof_df.loc[:, headers + samples_list]
+    prof_df.to_csv(args.output_file, sep="\t", index=False)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
When conducting large-scale profiling using Phanta, the merging of tables often takes minutes to hours. To address this issue, I have updated the code by switching from R to Python. This change allows for more efficient table merging.